### PR TITLE
[FIX] easy_my_coop: 't' in mail template

### DIFF
--- a/easy_my_coop/data/mail_template_data.xml
+++ b/easy_my_coop/data/mail_template_data.xml
@@ -18,44 +18,44 @@
             <field name="body_html"><![CDATA[
 <div style="font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; ">
 
-<p>Hello ${object.partner_id.name},</p>
+    <p>Hello ${object.partner_id.name},</p>
 
-<p>You will find in attachment all the necessary information for the payment. We kindly remind you that your subscription will be effective only once we received the payment.</p>
+    <p>You will find in attachment all the necessary information for the payment. We kindly remind you that your subscription will be effective only once we received the payment.</p>
 
-<p>Do not forget to add the structured communication to the payment.</p>
+    <p>Do not forget to add the structured communication to the payment.</p>
 
-<p>Sustainably your,</p>
-<p>${object.company_id.name}.</p>
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-      % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+    <div>
+        <img src=${object.company_id.logo_web}>
+    </div>
 </div>
             ]]></field>
         </record>
-       
+
         <record id="email_template_confirmation" model="mail.template">
             <field name="name">Confirmation Email</field>
             <field name="email_from">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
@@ -70,40 +70,40 @@
 
     <p>Hello ${object.name},</p>
 
-	<p>Your request will be soon processed by our team. If all the provided info are correct you will soon receive the payment information in another email</p>
+    <p>Your request will be soon processed by our team. If all the provided info are correct you will soon receive the payment information in another email</p>
 
     <br/>
     <p>If you have any question, do not hesitate to contact us.</p>
     <br/>
-    
-	<p>Sustainably your,</p>
-	<p>${object.company_id.name}.</p>
 
-% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-      % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
+
+    <div>
+        <img src=${object.company_id.logo_web}>
+    </div>
 </div>
             ]]></field>
         </record>
@@ -122,46 +122,46 @@
 
     <p>Hello ${object.name},</p>
 
-	<p>We have received your subscription request for ${object.company_id.name}. Thank you for your support.</p>
-	
-	<p>Your request will be soon processed by our team "gestion et participation des membres". If all the provided info are correct you will soon receive the payment information in another email</p>
+    <p>We have received your subscription request for ${object.company_id.name}. Thank you for your support.</p>
+
+    <p>Your request will be soon processed by our team "gestion et participation des membres". If all the provided info are correct you will soon receive the payment information in another email</p>
 
     <br/>
     <p>If you have any question, do not hesitate to contact us.</p>
     <br/>
-    
-	<p>Sustainably your,</p>
-	<p>${object.company_id.name}.</p>
 
-% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-      % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
+
+    <div>
+        <img src=${object.company_id.logo_web}>
+    </div>
 </div>
             ]]></field>
         </record>
-        
+
         <record id="email_template_certificat" model="mail.template">
             <field name="name">Payment Received Confirmation - Send By Email</field>
             <field name="email_from">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
@@ -171,7 +171,7 @@
             <field name="reply_to">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
             <field name="model_id" ref="model_res_partner"/>
             <field name="auto_delete" eval="True"/>
-            <field name="report_template" ref="action_cooperator_report_certificat"/> 
+            <field name="report_template" ref="action_cooperator_report_certificat"/>
             <field name="report_name">Certificat ${(object.cooperator_register_number or '')}</field>
             <field name="lang">${object.lang}</field>
             <field name="body_html"><![CDATA[
@@ -179,44 +179,44 @@
 
     <p>Hello ${object.name},</p>
 
-	<p>We confirm the reception of you payment. You are now shareholder of our cooperative</p>
+    <p>We confirm the reception of you payment. You are now shareholder of our cooperative</p>
 
     <br/>
     <p>Find in attachment your ${object.company_id.name} certificate.</p>
     <p>Thank you for choosing ${object.company_id.name or 'us'}!</p>
     <br/>
-	<p>Sustainably your,</p>
-	<p>${object.company_id.name}.</p>
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-		% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-      % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+    <div>
+        <img src=${object.company_id.logo_web}>
+    </div>
 </div>
             ]]></field>
         </record>
-        
+
         <record id="email_template_certificat_increase" model="mail.template">
             <field name="name">Share Increase - Payment Received Confirmation - Send By Email</field>
             <field name="email_from">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
@@ -225,7 +225,7 @@
             <field name="reply_to">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
             <field name="model_id" ref="model_res_partner"/>
             <field name="auto_delete" eval="True"/>
-            <field name="report_template" ref="action_cooperator_report_certificat"/> 
+            <field name="report_template" ref="action_cooperator_report_certificat"/>
             <field name="report_name">Certificat ${(object.cooperator_register_number or '')}</field>
             <field name="lang">${object.lang}</field>
             <field name="body_html"><![CDATA[
@@ -233,44 +233,44 @@
 
     <p>Hello ${object.name},</p>
 
-	<p>We confirm the reception of you payment for the new share(s) you have taken.</p>
+    <p>We confirm the reception of you payment for the new share(s) you have taken.</p>
 
     <br/>
     <p>Find in attachment your ${object.company_id.name} certificate.</p>
     <p>Thank you for trusting ${object.company_id.name or 'us'}!</p>
     <br/>
-	<p>Sustainably your,</p>
-	<p>${object.company_id.name}.</p>
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-		% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-       % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+    <div>
+        <img src=${object.company_id.logo_web}>
+    </div>
 </div>
             ]]></field>
-        </record>        
-        
+        </record>
+
         <record id="email_template_share_transfer" model="mail.template">
             <field name="name">Share transfer - Send By Email</field>
             <field name="email_from">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
@@ -279,7 +279,7 @@
             <field name="reply_to">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
             <field name="model_id" ref="model_res_partner"/>
             <field name="auto_delete" eval="True"/>
-            <field name="report_template" ref="action_cooperator_report_certificat"/> 
+            <field name="report_template" ref="action_cooperator_report_certificat"/>
             <field name="report_name">Certificat ${(object.cooperator_register_number or '')}</field>
             <field name="lang">${object.lang}</field>
             <field name="body_html"><![CDATA[
@@ -287,44 +287,44 @@
 
     <p>Hello ${object.name},</p>
 
-	<p>We confirm you that the shares have been transfered to you. If you was not already cooperator, you are now shareholder of our cooperative</p>
+    <p>We confirm you that the shares have been transfered to you. If you was not already cooperator, you are now shareholder of our cooperative</p>
 
     <br/>
     <p>Find in attachment your ${object.company_id.name} certificate.</p>
     <p>Thank you for choosing ${object.company_id.name or 'us'}!</p>
     <br/>
-	<p>Sustainably your,</p>
-	<p>${object.company_id.name}.</p>
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-		% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-      % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+    <div>
+        <img src=${object.company_id.logo_web}>
+    </div>
 </div>
             ]]></field>
         </record>
-        
+
         <record id="email_template_share_update" model="mail.template">
             <field name="name">Share update - Send By Email</field>
             <field name="email_from">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
@@ -333,7 +333,7 @@
             <field name="reply_to">${(object.company_id.coop_email_contact or object.user_id.email)|safe}</field>
             <field name="model_id" ref="model_res_partner"/>
             <field name="auto_delete" eval="True"/>
-            <field name="report_template" ref="action_cooperator_report_certificat"/> 
+            <field name="report_template" ref="action_cooperator_report_certificat"/>
             <field name="report_name">Certificat ${(object.cooperator_register_number or '')}</field>
             <field name="lang">${object.lang}</field>
             <field name="body_html"><![CDATA[
@@ -341,42 +341,42 @@
 
     <p>Hello ${object.name},</p>
 
-	<p>We confirm you that the adaptation on shares portfolio has been succesfully performed. Your cooperator certificate has been adapted accordingly</p>
+    <p>We confirm you that the adaptation on shares portfolio has been succesfully performed. Your cooperator certificate has been adapted accordingly</p>
 
     <br/>
     <p>Find in attachment your ${object.company_id.name} certificate.</p>
     <p>Thank you for choosing ${object.company_id.name or 'us'}!</p>
     <br/>
-	<p>Sustainably your,</p>
-	<p>${object.company_id.name}.</p>
+    <p>Sustainably your,</p>
+    <p>${object.company_id.name}.</p>
 
-		% if object.company_id.street:
-            ${object.company_id.street}
-        % endif
-        % if object.company_id.street2:
-            ${object.company_id.street2}<br/>
-        % endif
-        % if object.company_id.city or object.company_id.zip:
-            ${object.company_id.zip} ${object.company_id.city}<br/>
-        % endif
-        % if object.company_id.country_id:
-            ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
-        % endif
-        % if object.company_id.phone:
-                Phone:&nbsp; ${object.company_id.phone}
-        % endif
+    % if object.company_id.street:
+        ${object.company_id.street}
+    % endif
+    % if object.company_id.street2:
+        ${object.company_id.street2}<br/>
+    % endif
+    % if object.company_id.city or object.company_id.zip:
+        ${object.company_id.zip} ${object.company_id.city}<br/>
+    % endif
+    % if object.company_id.country_id:
+        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>
+    % endif
+    % if object.company_id.phone:
+        Phone:&nbsp; ${object.company_id.phone}
+    % endif
 
-      % if object.company_id.website:
-            <div>
-                Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
-            </div>
-       %endif
+    % if object.company_id.website:
+        <div>
+            Web :&nbsp;<a href="${object.company_id.website}">${object.company_id.website}</a>
+        </div>
+    %endif
 
-       <div>
-          <img src=${object.company_id.logo_web}>
-       </div>
+     <div>
+         <img src=${object.company_id.logo_web}>
+     </div>
 </div>
             ]]></field>
         </record>
-	</data>
+    </data>
 </odoo>

--- a/easy_my_coop/i18n/fr_BE.po
+++ b/easy_my_coop/i18n/fr_BE.po
@@ -6,421 +6,620 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-13 08:42+0000\n"
-"PO-Revision-Date: 2016-07-13 11:28+0100\n"
+"POT-Creation-Date: 2018-03-27 08:18+0000\n"
+"PO-Revision-Date: 2018-03-27 08:18+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: fr_BE\n"
-"X-Generator: Poedit 1.6.5\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: easy_my_coop
 #: model:mail.template,body_html:easy_my_coop.email_template_certificat_increase
-msgid ""
-"\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
 "    <p>Hello ${object.name},</p>\n"
 "\n"
-"\t<p>We confirm the reception of you payment for the new share(s) you have "
-"taken.</p>\n"
+"    <p>We confirm the reception of you payment for the new share(s) you have taken.</p>\n"
 "\n"
 "    <br/>\n"
-"    <p>Find in attachment the your ${object.company_id} certificate.</p>\n"
+"    <p>Find in attachment your ${object.company_id.name} certificate.</p>\n"
 "    <p>Thank you for trusting ${object.company_id.name or 'us'}!</p>\n"
 "    <br/>\n"
-"\t<p>Sustainably your,</p>\n"
-"\t<p>${object.company_id.name}.</p>\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"\t\t% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"       % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
 "\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
-msgstr ""
-"\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
 "    <p>Bonjour ${object.name},</p>\n"
 "\n"
-"<p>Nous vous confirmons la réception de votre paiement pour les nouvelles "
-"parts souscrites.</p>\n"
+"    <p>Nous confirmons la réception de votre paiement pour vos nouvelles parts.</p>\n"
 "\n"
-"    <br>   <p>Vous trouverez votre certificat de coopérateur en pièce jointe."
-"</p>\n"
-"    <p>Merci de soutenir ${object.company_id.name}!</p>\n"
-"<p>Amicalement,</p>\n"
-"<p>${object.company_id.name}.</p>\n"
+"    <br/>\n"
+"    <p>Vous trouverez en pièce jointe votre certificat ${object.company_id.name}.</p>\n"
+"    <p>Merci de faire confiance à ${object.company_id.name or 'us'} !</p>\n"
+"    <br/>\n"
+"    <p>Coopérativement vôtre,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br><p style=\"margin:0px 0px 10px "
-"0px;\"></p><p style=\"margin:0px 0px 10px 0px;\">\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br></p><p "
-"style=\"margin:0px 0px 10px 0px;\">\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br></p>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"            Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"       % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a style=\"text-decoration-style:solid;text-"
-"decoration-line:none;text-decoration-color:-moz-use-text-color;color:rgb(51, "
-"122, 183);background-color:transparent;\" href=\"${object.company_id."
-"website}\">${object.company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
 "\n"
-"       <div>\n"
-"          <img src=\"${object.company_id.logo_web}\">\n"
-"       </div>\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
-"           "
+"            "
 
 #. module: easy_my_coop
 #: model:mail.template,body_html:easy_my_coop.email_template_certificat
-msgid ""
-"\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
 "    <p>Hello ${object.name},</p>\n"
 "\n"
-"\t<p>We confirm the reception of you payment. You are now shareholder of our "
-"cooperative</p>\n"
+"    <p>We confirm the reception of you payment. You are now shareholder of our cooperative</p>\n"
 "\n"
 "    <br/>\n"
-"    <p>Find in attachment the your ${object.company_id.name} certificate.</"
-"p>\n"
+"    <p>Find in attachment your ${object.company_id.name} certificate.</p>\n"
 "    <p>Thank you for choosing ${object.company_id.name or 'us'}!</p>\n"
 "    <br/>\n"
-"\t<p>Sustainably your,</p>\n"
-"\t<p>${object.company_id.name}.</p>\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"\t\t% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"      % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
 "\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
-msgstr ""
-"\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
 "    <p>Bonjour ${object.name},</p>\n"
 "\n"
-"<p>Nous vous confirmons la réception de votre paiement pour les parts "
-"souscrites.</p>\n"
+"    <p>Nous confirmons la réception de votre paiement. Vous êtes maintenant coopérateur de notre coopérative.</p>\n"
 "\n"
 "    <br/>\n"
-"    <p>Vous trouverez votre certificat de coopérateur en pièce jointe.</p>\n"
-"    <p>Merci de soutenir ${object.company_id.name}!</p>\n"
+"    <p>Vous trouverez en pièce jointe votre certificat ${object.company_id.name}.</p>\n"
+"    Merci de faire confiance à ${object.company_id.name or 'us'} !</p>\n"
 "    <br/>\n"
-"<p>Amicalement,</p>\n"
-"<p>${object.company_id.name}.</p>\n"
+"    <p>Coopérativement vôtre,</p>\n"
 "\n"
-"% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"      % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
+"</div>\n"
+"            "
+
+#. module: easy_my_coop
+#: model:mail.template,body_html:easy_my_coop.email_template_share_update
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"\n"
+"    <p>Hello ${object.name},</p>\n"
+"\n"
+"    <p>We confirm you that the adaptation on shares portfolio has been succesfully performed. Your cooperator certificate has been adapted accordingly</p>\n"
+"\n"
+"    <br/>\n"
+"    <p>Find in attachment your ${object.company_id.name} certificate.</p>\n"
+"    <p>Thank you for choosing ${object.company_id.name or 'us'}!</p>\n"
+"    <br/>\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
+"\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"     <div>\n"
+"         <img src=${object.company_id.logo_web}>\n"
+"     </div>\n"
+"</div>\n"
+"            "
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"\n"
+"    <p>Bonjour ${object.name},</p>\n"
+"\n"
+"    <p>Nous confirmons que vos parts ont été adaptées. Votre certificat de coopérateur a été adapté conformément.</p>\n"
+"\n"
+"    <br/>\n"
+"    <p>Vous trouverez en pièce jointe votre certificat ${object.company_id.name}.</p>\n"
+"    <p>Merci d'avoir choisi ${object.company_id.name or 'us'} !</p>\n"
+"    <br/>\n"
+"    <p>Coopérativement vôtre,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
+"\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"     <div>\n"
+"         <img src=${object.company_id.logo_web}>\n"
+"     </div>\n"
+"</div>\n"
+"            "
+
+#. module: easy_my_coop
+#: model:mail.template,body_html:easy_my_coop.email_template_share_transfer
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"\n"
+"    <p>Hello ${object.name},</p>\n"
+"\n"
+"    <p>We confirm you that the shares have been transfered to you. If you was not already cooperator, you are now shareholder of our cooperative</p>\n"
+"\n"
+"    <br/>\n"
+"    <p>Find in attachment your ${object.company_id.name} certificate.</p>\n"
+"    <p>Thank you for choosing ${object.company_id.name or 'us'}!</p>\n"
+"    <br/>\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
+"\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
+"</div>\n"
+"            "
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"\n"
+"    <p>Bonjour ${object.name},</p>\n"
+"\n"
+"    <p>Nous confirmons que des parts vous ont été transférées. Si vous n'étiez pas déjà coopérateur, vous êtes maintenant coopérateur de notre coopérative.</p>\n"
+"\n"
+"    <br/>\n"
+"    <p>Vous trouverez en pièce jointe votre certificat {object.company_id.name}.</p>\n"
+"    <p>Merci d'avoir choisi ${object.company_id.name or 'us'} !</p>\n"
+"    <br/>\n"
+"    <p>Coopérativement vôtre,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
+"\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
+"</div>\n"
+"            "
+
+#. module: easy_my_coop
+#: model:mail.template,body_html:easy_my_coop.email_template_confirmation_company
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"\n"
+"    <p>Hello ${object.name},</p>\n"
+"\n"
+"    <p>We have received your subscription request for ${object.company_name} ${object.company_type}. Thank you for your support.</p>\n"
+"\n"
+"    <p>Your request will be soon processed by our team \"gestion et participation des membres\". If all the provided info are correct you will soon receive the payment information in another email</p>\n"
+"\n"
+"    <br/>\n"
+"    <p>If you have any question, do not hesitate to contact us.</p>\n"
+"    <br/>\n"
+"\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
+"\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
+"</div>\n"
+"            "
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"\n"
+"    <p>Bonjour ${object.name},</p>\n"
+"\n"
+"    <p>Nous avons reçu votre demande de souscription auprès de ${object.company_name} ${object.company_type}. Merci pour votre support.</p>\n"
+"\n"
+"    <p>Votre demande va être prochainement traitée par notre équipe. Si toutes les informations fournies sont correctes, vous recevrez bientôt les informations de paiement dans un autre mail.</p>\n"
+"\n"
+"    <br>\n"
+"    <p>Si vous avez la moindre question, n'hésitez pas à nous contacter.</p>\n"
+"    <br>\n"
+"    \n"
+"    <p>Coopérativement vôtre,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
+"\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
 
 #. module: easy_my_coop
 #: model:mail.template,body_html:easy_my_coop.email_template_confirmation
-msgid ""
-"\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
 "    <p>Hello ${object.name},</p>\n"
 "\n"
-"\t<p>Your request will be soon processed by our team. If all the provided "
-"info are correct you will soon receive the payment information in another "
-"email</p>\n"
+"    <p>Your request will be soon processed by our team. If all the provided info are correct you will soon receive the payment information in another email</p>\n"
 "\n"
 "    <br/>\n"
 "    <p>If you have any question, do not hesitate to contact us.</p>\n"
 "    <br/>\n"
-"    \n"
-"\t<p>Sustainably your,</p>\n"
-"\t<p>${object.company_id.name}.</p>\n"
 "\n"
-"% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"      % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
-msgstr ""
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"    <p>Bonjour ${object.name},</p>\n"
 "\n"
-"<p>Bonjour ${object.name},</p><p>Nous avons bien reçu votre demande de "
-"souscription de parts. Merci pour votre soutien.</p><p>Votre demande sera "
-"bientôt traitée par la cellule \"gestion et participation des membres\". Si "
-"toutes les informations fournies sont correctes, vous recevrez bientôt les "
-"informations pour le paiement de vos parts dans un prochain email.</"
-"p><p>N’hésitez pas à nous contacter pour toute question.</p><br/"
-"><p>Amicalement,</p><p>${object.company_id.name}.</p>\n"
-"% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    <p>Votre demande va être prochainement traitée par notre équipe. Si toutes les informations fournies sont correctes, vous recevrez prochainement les informations de paiement dans un autre mail.</p>\n"
 "\n"
-"      % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
+"    <br/>\n"
+"    <p>Si vous avez la moindre question, n'hésitez pas à nous contacter.</p>\n"
+"    <br/>\n"
+"    \n"
+"    <p>Coopérativement vôtre,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
+"\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
+"\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
 
 #. module: easy_my_coop
 #: model:mail.template,body_html:easy_my_coop.email_template_release_capital
-msgid ""
+msgid "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"    <p>Hello ${object.partner_id.name},</p>\n"
 "\n"
-"<p>Hello ${object.partner_id.name},</p>\n"
+"    <p>You will find in attachment all the necessary information for the payment. We kindly remind you that your subscription will be effective only once we received the payment.</p>\n"
 "\n"
-"<p>You will find in attachment all the necessary information for the "
-"payment. We kindly remind you that your subscription will be effective only "
-"once we received the payment.</p>\n"
+"    <p>Do not forget to add the structured communication to the payment.</p>\n"
 "\n"
-"<p>Do not forget to add the structured communication to the payment.</p>\n"
+"    <p>Sustainably your,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"<p>Sustainably your,</p>\n"
-"<p>${object.company_id.name}.</p>\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
 "\n"
-"      % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
-"\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
-msgstr ""
+msgstr "\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
 "\n"
-"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
-"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"    <p>Bonjour ${object.partner_id.name},</p>\n"
 "\n"
-"<p>Bonjour ${object.partner_id.name},</p>\n"
+"    <p>Vous trouverez en pièce jointe toutes les informations pour le paiement de vos parts. Votre souscription sera effective une fois que nous avons réceptionné votre paiement.</p>\n"
 "\n"
-"<p>Vous trouverez en pièce jointe toutes les informations nécessaires pour "
-"le paiement des parts souscrites. Nous vous rappelons que votre inscription "
-"sera effective lorsque vous aurez libéré le paiement sur notre compte "
-"bancaire.</p>\n"
+"    <p>N'oubliez pas d'utiliser la communication structurée pour le paiement.</p>\n"
 "\n"
-"<p>Pour faciliter notre gestion administrative, n’oubliez pas d’utiliser la "
-"communication structurée</p>\n"
+"    <p>Coopérativement vôtre,</p>\n"
+"    <p>${object.company_id.name}.</p>\n"
 "\n"
-"<p>Amicalement,</p>\n"
-"<p>${object.company_id.name}.</p>\n"
+"    % if object.company_id.street:\n"
+"        ${object.company_id.street}\n"
+"    % endif\n"
+"    % if object.company_id.street2:\n"
+"        ${object.company_id.street2}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.city or object.company_id.zip:\n"
+"        ${object.company_id.zip} ${object.company_id.city}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.country_id:\n"
+"        ${object.company_id.state_id and ('%s, ' % object.company_id.state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
+"    % endif\n"
+"    % if object.company_id.phone:\n"
+"        Phone:&nbsp; ${object.company_id.phone}\n"
+"    % endif\n"
 "\n"
-"% if object.company_id.street:\n"
-"            ${object.company_id.street}\n"
-"        % endif\n"
-"        % if object.company_id.street2:\n"
-"            ${object.company_id.street2}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.city or object.company_id.zip:\n"
-"            ${object.company_id.zip} ${object.company_id.city}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.country_id:\n"
-"            ${object.company_id.state_id and ('%s, ' % object.company_id."
-"state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
-"        % endif\n"
-"        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
-"        % endif\n"
+"    % if object.company_id.website:\n"
+"        <div>\n"
+"            Web :&nbsp;<a href=\"${object.company_id.website}\">${object.company_id.website}</a>\n"
+"        </div>\n"
+"    %endif\n"
 "\n"
-"      % if object.company_id.website:\n"
-"            <div>\n"
-"                Web :&nbsp;<a href=\"${object.company_id.website}\">${object."
-"company_id.website}</a>\n"
-"            </div>\n"
-"       %endif\n"
-"\n"
-"       <div>\n"
-"          <img src=${object.company_id.logo_web}>\n"
-"       </div>\n"
+"    <div>\n"
+"        <img src=${object.company_id.logo_web}>\n"
+"    </div>\n"
 "</div>\n"
 "            "
 
 #. module: easy_my_coop
 #: model:mail.template,report_name:easy_my_coop.email_template_release_capital
-msgid ""
-"${(object.number or '').replace('/','_')}_${object.state == 'draft' and "
-"'draft' or ''}"
-msgstr ""
-"${(object.number or '').replace('/','_')}_${object.state == 'draft' and "
-"'draft' or ''}"
+msgid "${(object.number or '').replace('/','_')}_${object.state == 'draft' and 'draft' or ''}"
+msgstr "${(object.number or '').replace('/','_')}_${object.state == 'draft' and 'draft' or ''}"
 
 #. module: easy_my_coop
 #: model:mail.template,subject:easy_my_coop.email_template_release_capital
-msgid ""
-"${object.company_id.name} Request to Release Capital (Ref ${object.number or "
-"'n/a'})"
-msgstr ""
-"${object.company_id.name} Demande de libération de capital (Ref ${object."
-"number or 'n/a'})"
-
-#. module: easy_my_coop
-#: model:mail.template,report_name:easy_my_coop.email_template_certificat_increase
-msgid ""
-"${object.company_id} Certificat ${(object.cooperator_register_number or '')}"
-msgstr ""
-"${object.company_id} Certificat ${(object.cooperator_register_number or '')}"
+msgid "${object.company_id.name} Request to Release Capital (Ref ${object.number or 'n/a'})"
+msgstr "${object.company_id.name} Demande de libération de capital (Ref ${object.number or 'n/a'})"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_thanks
@@ -446,11 +645,6 @@ msgstr "1030"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
-msgid "1080"
-msgstr "1080"
-
-#. module: easy_my_coop
-#: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
 msgid "25"
 msgstr "25"
@@ -470,11 +664,11 @@ msgid ""
 "\n"
 "    <p style=\"margin:0px 0px 10px 0px;\">Hello ${object.name},</p>\n"
 "\n"
-"\t<p style=\"margin:0px 0px 10px 0px;\">We have received your subscription "
-"request for ${object.company_id.name}. Thank you for "
+"    <p style=\"margin:0px 0px 10px 0px;\">We have received your "
+"subscription request for ${object.company_id.name}. Thank you for "
 "your support.</p>\n"
-"\t\n"
-"\t<p style=\"margin:0px 0px 10px 0px;\">Your request will be soon processed "
+"\n"
+"    <p style=\"margin:0px 0px 10px 0px;\">Your request will be soon processed "
 "by our team \"gestion et participation des membres\". If all the provided "
 "info are correct you will soon receive the payment information in another "
 "email</p>\n"
@@ -486,10 +680,10 @@ msgid ""
 "    <br><p style=\"margin:0px 0px 10px 0px;\"></p><p style=\"margin:0px 0px "
 "10px 0px;\">\n"
 "    \n"
-"\t</p><p style=\"margin:0px 0px 10px 0px;\">Sustainably your,</p>\n"
-"\t<p style=\"margin:0px 0px 10px 0px;\">${object.company_id.name}.</p>\n"
+"    </p><p style=\"margin:0px 0px 10px 0px;\">Sustainably your,</p>\n"
+"    <p style=\"margin:0px 0px 10px 0px;\">${object.company_id.name}.</p>\n"
 "\n"
-"% if object.company_id.street:\n"
+"        % if object.company_id.street:\n"
 "            ${object.company_id.street}\n"
 "        % endif\n"
 "        % if object.company_id.street2:\n"
@@ -506,10 +700,10 @@ msgid ""
 "style=\"margin:0px 0px 10px 0px;\">\n"
 "        % endif\n"
 "        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
+"            Phone:&nbsp; ${object.company_id.phone}\n"
 "        % endif\n"
 "\n"
-"      % if object.company_id.website:\n"
+"        % if object.company_id.website:\n"
 "            </p><div>\n"
 "                Web :&nbsp;<a style=\"text-decoration-style:solid;text-"
 "decoration-line:none;text-decoration-color:-moz-use-text-color;color:rgb(51, "
@@ -553,7 +747,7 @@ msgstr ""
 "<p>Sustainably your,</p>\n"
 "<p>${object.company_id.name}.</p>\n"
 "\n"
-"% if object.company_id.street:\n"
+"        %if object.company_id.street:\n"
 "            ${object.company_id.street}\n"
 "        % endif\n"
 "        % if object.company_id.street2:\n"
@@ -567,7 +761,7 @@ msgstr ""
 "state_id.name) or ''} ${object.company_id.country_id.name or ''}<br/>\n"
 "        % endif\n"
 "        % if object.company_id.phone:\n"
-"                Phone:&nbsp; ${object.company_id.phone}\n"
+"            Phone:&nbsp; ${object.company_id.phone}\n"
 "        % endif\n"
 "\n"
 "      % if object.company_id.website:\n"
@@ -617,12 +811,7 @@ msgstr "<span>REGISTRE DES SOUSCRIPTIONS </span>"
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "<strong>Account Number:</strong>"
-msgstr "<strong>Compte bancaire:</strong>"
-
-#. module: easy_my_coop
-#: model:ir.ui.view,arch_db:easy_my_coop.cooperator_certificat_G001_document
-msgid "<strong>Carine Sottiaux</strong>"
-msgstr "<strong>Carine Sottiaux</strong>"
+msgstr "<strong>Compte bancaire :</strong>"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
@@ -657,7 +846,7 @@ msgstr "<strong>Date de la facture :</strong>"
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "<strong>Request Date:</strong>"
-msgstr "<strong>Date de la demande:</strong>"
+msgstr "<strong>Date de la demande :</strong>"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
@@ -667,7 +856,7 @@ msgstr "<strong>Origine :</strong>"
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "<strong>Structured Communication:</strong>"
-msgstr "<strong>Communication Structurée:</strong>"
+msgstr "<strong>Communication Structurée :</strong>"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
@@ -678,6 +867,17 @@ msgstr "<strong>Sous-total</strong>"
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "<strong>Total</strong>"
 msgstr "<strong>Total</strong>"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
+msgid "<strong>Your contact:</strong>"
+msgstr "<strong>Votre contact :</strong>"
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/wizard/create_subscription_from_partner.py:166
+#, python-format
+msgid "A person can't be representative of two differents companies."
+msgstr "Une personne ne peut pas être la représentante de deux entreprises différentes."
 
 #. module: easy_my_coop
 #: selection:subscription.request,company_type:0
@@ -692,7 +892,7 @@ msgstr "Numéro de compte"
 #. module: easy_my_coop
 #: sql_constraint:res.partner.bank:0
 msgid "Account Number must be unique!"
-msgstr "Le numéro de compte en banque doit-être unique!"
+msgstr "Le numéro de compte en banque doit-être unique !"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_activities_address
@@ -722,9 +922,24 @@ msgid "Address"
 msgstr "Adresse"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
+msgid "Already cooperator?"
+msgstr "Déjà coopérateur ?"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "Amount"
 msgstr "Montant"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
+msgid "Approve"
+msgstr "Approuver"
+
+#. module: easy_my_coop
+#: selection:operation.request,state:0
+msgid "Approved"
+msgstr "Approuvé"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
@@ -744,11 +959,21 @@ msgid "Bank Accounts"
 msgstr "Comptes bancaires"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_bank_account
+msgid "Bank account"
+msgstr "Compte bancaire"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
+msgid "Base"
+msgstr "Base"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,help:easy_my_coop.field_operation_request_share_unit_price
+#: model:ir.model.fields,help:easy_my_coop.field_partner_create_subscription_share_unit_price
 #: model:ir.model.fields,help:easy_my_coop.field_subscription_request_share_unit_price
-msgid ""
-"Base price to compute the customer price. Sometimes called the catalog price."
-msgstr ""
-"Prix de base pour calculer le prix client. Parfois appelé prix catalogue."
+msgid "Base price to compute the customer price. Sometimes called the catalog price."
+msgstr "Prix de base pour calculer le prix client. Parfois appelé prix catalogue."
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
@@ -760,6 +985,11 @@ msgstr "Devenir coopérateur"
 #: model:website.menu,name:easy_my_coop.menu_becomecooperator
 msgid "Become cooperator"
 msgstr "Devenir coopérateur"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_product_template_customer
+msgid "Become customer"
+msgstr "Devenir client"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_birthdate
@@ -774,6 +1004,26 @@ msgid "Blocked"
 msgstr "Bloquée"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_board_representative
+msgid "Board representative name"
+msgstr "Représentant du conseil d'administration"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_signature_scan
+msgid "Board representative signature"
+msgstr "Signature du représentant du CA"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_bottom_logo1
+msgid "Bottom logo 1"
+msgstr "Bottom logo 1"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_bottom_logo2
+msgid "Bottom logo 2"
+msgstr "Bottom logo 2"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
 msgid "Bourdon"
@@ -786,21 +1036,30 @@ msgid "Bruxelles"
 msgstr "Bruxelles"
 
 #. module: easy_my_coop
+#: selection:subscription.request,source:0
+msgid "CRM"
+msgstr "CRM"
+
+#. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_product_template_by_company
 msgid "Can be subscribed by companies?"
-msgstr "Peut-être souscrite par des sociétés?"
+msgstr "Peut-être souscrite par des sociétés ?"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_product_template_by_individual
 msgid "Can be subscribed by individuals?"
-msgstr "Peut-être souscrite par des personnes physiques?"
+msgstr "Peut-être souscrite par des personnes physiques ?"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
 #: model:ir.ui.view,arch_db:easy_my_coop.subscription_request_form
+#: model:ir.ui.view,arch_db:easy_my_coop.view_create_subscription
+#: model:ir.ui.view,arch_db:easy_my_coop.view_update_partner_info
 msgid "Cancel"
 msgstr "Annuler"
 
 #. module: easy_my_coop
+#: selection:operation.request,state:0
 #: selection:subscription.request,state:0
 msgid "Cancelled"
 msgstr "Annulé"
@@ -811,19 +1070,32 @@ msgid "Cancelled Invoice"
 msgstr "Facture annulée"
 
 #. module: easy_my_coop
+#: model:ir.actions.report.xml,name:easy_my_coop.action_cooperator_invoices
+msgid "Capital release request"
+msgstr "Demande de libération de capital"
+
+#. module: easy_my_coop
 #: model:mail.template,report_name:easy_my_coop.email_template_certificat
+#: model:mail.template,report_name:easy_my_coop.email_template_certificat_increase
+#: model:mail.template,report_name:easy_my_coop.email_template_share_transfer
+#: model:mail.template,report_name:easy_my_coop.email_template_share_update
 msgid "Certificat ${(object.cooperator_register_number or '')}"
 msgstr "Certificat ${(object.cooperator_register_number or '')}"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,help:easy_my_coop.field_res_partner_cooperator
-msgid "Check this box if this contact is a cooperator."
-msgstr "Cochez cette case si le contact est un cooperateur."
+msgid "Check this box if this contact is a cooperator(effective or not)."
+msgstr "Cocher cette case si le contact est un coopérateur (effectif ou non)."
 
 #. module: easy_my_coop
 #: model:ir.model.fields,help:easy_my_coop.field_res_partner_member
-msgid "Check this box if this cooperator is a effective member."
-msgstr "Cochez cette case si le contact est un membre effectif."
+msgid "Check this box if this cooperator is an effective member."
+msgstr "Cochez cette case si le coopérateur est un membre effectif."
+
+#. module: easy_my_coop
+#: model:ir.model.fields,help:easy_my_coop.field_res_partner_old_member
+msgid "Check this box if this cooperator is no more an effective member."
+msgstr "Cochez cette case si le coopérateur n'est plus un membre effectif."
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_city
@@ -833,6 +1105,7 @@ msgid "City"
 msgstr "Ville"
 
 #. module: easy_my_coop
+#: model:ir.actions.act_window,help:easy_my_coop.action_company_representative_form
 #: model:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_candidate_form
 #: model:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_form
 msgid "Click to add a contact in your address book."
@@ -841,12 +1114,12 @@ msgstr "Cliquer pour ajouter un contact dans le carnet d'adresses."
 #. module: easy_my_coop
 #: model:ir.actions.act_window,help:easy_my_coop.action_invoice_tree_coop
 msgid "Click to create a cooperator invoice."
-msgstr "Clickez pour créer une demande de libération de capital"
+msgstr "Cliquez pour créer une demande de libération de capital."
 
 #. module: easy_my_coop
 #: model:ir.actions.act_window,help:easy_my_coop.share_product_action
 msgid "Click to define a new share product."
-msgstr "Cliquez pour définir un nouveau type de part"
+msgstr "Cliquez pour définir un nouveau type de part."
 
 #. module: easy_my_coop
 #: model:ir.model,name:easy_my_coop.model_res_company
@@ -854,6 +1127,7 @@ msgid "Companies"
 msgstr "Sociétés"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_company_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_company_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_company_id
 msgid "Company"
@@ -870,6 +1144,7 @@ msgid "Company Info"
 msgstr "Info société"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_company_register_number
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 msgid "Company Register Number"
 msgstr "Numéro d'entreprise"
@@ -877,9 +1152,10 @@ msgstr "Numéro d'entreprise"
 #. module: easy_my_coop
 #: model:product.category,name:easy_my_coop.product_category_company_share
 msgid "Company Share"
-msgstr "Parts de la coopérative"
+msgstr "Part société"
 
 #. module: easy_my_coop
+#: model:ir.actions.act_window,name:easy_my_coop.company_subscription_request_action
 #: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_company_subscription_request
 msgid "Company Subscription"
 msgstr "Personnes morales"
@@ -899,13 +1175,24 @@ msgstr "Nom de la société"
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_company_register_number
 msgid "Company register number"
-msgstr "Numéro d'Entreprise"
+msgstr "Numéro d'entreprise"
+
+#. module: easy_my_coop
+#: model:ir.actions.act_window,name:easy_my_coop.action_company_representative_form
+#: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_company_representative
+msgid "Company representative"
+msgstr "Représentant de l'entreprise"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_company_type
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 msgid "Company type"
 msgstr "Type de société"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_share_product_id_to
+msgid "Concert to this share type"
+msgstr "Concert to this share type"
 
 #. module: easy_my_coop
 #: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_config
@@ -923,8 +1210,17 @@ msgid "Contact email address for the cooperator"
 msgstr "Email du coopérateur"
 
 #. module: easy_my_coop
+#: selection:operation.request,operation_type:0
+#: selection:subscription.register,type:0
+msgid "Conversion"
+msgstr "Conversion"
+
+#. module: easy_my_coop
 #: model:ir.actions.act_window,name:easy_my_coop.action_partner_cooperator_candidate_form
 #: model:ir.actions.act_window,name:easy_my_coop.action_partner_cooperator_form
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_partner_id
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_cooperator
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_cooperator
 #: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_cooperator
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_partner_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_partner_id
@@ -934,13 +1230,17 @@ msgid "Cooperator"
 msgstr "Coopérateur"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_property_cooperator_account
+msgid "Cooperator Account"
+msgstr "Compte général coopérateur"
+
+#. module: easy_my_coop
 #: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_cooperator_candidate
 msgid "Cooperator Candidates"
 msgstr "Candidats coopérateur"
 
 #. module: easy_my_coop
 #: model:ir.actions.act_window,name:easy_my_coop.action_invoice_tree_coop
-#: model:ir.actions.report.xml,name:easy_my_coop.action_cooperator_invoices
 #: model:ir.ui.menu,name:easy_my_coop.menu_action_invoice_tree_coop
 msgid "Cooperator Invoices"
 msgstr "Demande de libération de capital"
@@ -956,7 +1256,6 @@ msgid "Cooperator Partners"
 msgstr "Cooperateurs"
 
 #. module: easy_my_coop
-#: model:ir.actions.act_window,name:easy_my_coop.company_subscription_request_action
 #: model:ir.actions.act_window,name:easy_my_coop.subscription_request_action
 #: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_subscription_request
 msgid "Cooperator Subscription"
@@ -968,14 +1267,24 @@ msgid "Cooperator Subscriptions Request"
 msgstr "Personnes physiques"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_cooperator_type
+msgid "Cooperator Type"
+msgstr "Type de coopérateur"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_coop_candidate
+msgid "Cooperator candidate"
+msgstr "Candidat coopérateur"
+
+#. module: easy_my_coop
 #: model:ir.actions.report.xml,name:easy_my_coop.action_cooperator_report_certificat
 msgid "Cooperator certificat"
-msgstr "Certificat coopérateur"
+msgstr "Certificat du coopérateur"
 
 #. module: easy_my_coop
 #: model:ir.actions.report.xml,name:easy_my_coop.action_report_cooperator_register
 msgid "Cooperator register"
-msgstr "Registre des cooperateurs"
+msgstr "Registre des coopérateurs"
 
 #. module: easy_my_coop
 #: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_cooperator
@@ -998,6 +1307,21 @@ msgid "Country..."
 msgstr "Pays..."
 
 #. module: easy_my_coop
+#: model:ir.actions.act_window,name:easy_my_coop.action_view_create_subscription
+#: model:ir.ui.view,arch_db:easy_my_coop.view_create_subscription
+#: model:ir.ui.view,arch_db:easy_my_coop.view_partner_form_easy_my_coop
+msgid "Create Subscription"
+msgstr "Créer une souscription"
+
+#. module: easy_my_coop
+#: model:ir.model,name:easy_my_coop.model_partner_create_subscription
+msgid "Create Subscription From Partner"
+msgstr "Créer une souscription depuis le partenaire"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_create_uid
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_create_uid
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_create_uid
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_create_uid
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_create_uid
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_create_uid
@@ -1005,6 +1329,9 @@ msgid "Created by"
 msgstr "Créé par"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_create_date
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_create_date
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_create_date
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_create_date
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_create_date
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_create_date
@@ -1048,6 +1375,9 @@ msgid "Disc.(%)"
 msgstr "Rem.(%)"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_display_name
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_display_name
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_display_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_display_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_display_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_display_name
@@ -1055,16 +1385,29 @@ msgid "Display Name"
 msgstr "Nom affiché"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_display_logo1
+msgid "Display logo 1"
+msgstr "Display logo 1"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_display_logo2
+msgid "Display logo 2"
+msgstr "Display logo 2"
+
+#. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_product_template_display_on_website
 msgid "Display on website"
 msgstr "Afficher sur le site web"
 
 #. module: easy_my_coop
+#: selection:operation.request,state:0
 #: selection:subscription.request,state:0
 msgid "Done"
 msgstr "Fait"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
+#: selection:operation.request,state:0
 #: selection:subscription.request,state:0
 msgid "Draft"
 msgstr "Brouillon"
@@ -1096,12 +1439,14 @@ msgid "Effective cooperator"
 msgstr "Coopérateur effectif"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_effective_date
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_certificat_G001_document
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_register_G001
 msgid "Effective date"
 msgstr "Date effective"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_email
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_email
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
@@ -1113,7 +1458,20 @@ msgstr "Courriel"
 #: code:addons/easy_my_coop/wizard/cooperative_history_wizard.py:53
 #, python-format
 msgid "Error!"
-msgstr "Erreur!"
+msgstr "Erreur !"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
+msgid "Execute"
+msgstr "Exécuter"
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/coop.py:119
+#: selection:res.partner,gender:0
+#: selection:subscription.request,gender:0
+#, python-format
+msgid "Female"
+msgstr "Féminin"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
@@ -1127,15 +1485,38 @@ msgid "Firstname"
 msgstr "Prénom"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_product_template_force_min_qty
+msgid "Force min qty"
+msgstr "Forcer le nombre minimal"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_capital_release_request_date
+msgid "Force the capital release request date"
+msgstr "Frocer la date de libération de capital"
+
+#. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_contact_person_function
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 msgid "Function"
 msgstr "Fonction"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_gender
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_gender
+#: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
+#: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
+msgid "Gender"
+msgstr "Genre"
+
+#. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_account_journal_get_cooperator_payment
-msgid "Get cooperator payment?"
-msgstr "Obtenir le paiement de coopérateurs?"
+msgid "Get cooperator payments?"
+msgstr "Reçoit les paiements de coopérateur ?"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_account_journal_get_general_payment
+msgid "Get general payments?"
+msgstr "Reçoit les paiements généraux ?"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.view_subscription_request_filter
@@ -1145,9 +1526,17 @@ msgstr "Regrouper par"
 #. module: easy_my_coop
 #: model:ir.module.category,description:easy_my_coop.module_category_cooperator_management
 msgid "Helps you manage your cooperator."
-msgstr "Vous aides à gérer vos coopérateurs."
+msgstr "Vous aide à gérer vos coopérateurs."
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_already_cooperator
+msgid "I'm already cooperator"
+msgstr "Je suis déjà coopérateur"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_id
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_id
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_id
@@ -1155,14 +1544,19 @@ msgid "ID"
 msgstr "ID"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,help:easy_my_coop.field_res_company_unmix_share_type
+msgid "If checked, A cooperator will be authorized to have only one type of share"
+msgstr "Si coché, un coopérateur ne sera authorisé à n'avoir qu'un seul type de part."
+
+#. module: easy_my_coop
 #: model:ir.model.fields,help:easy_my_coop.field_subscription_request_lang
-msgid ""
-"If the selected language is loaded in the system, all documents related to "
-"this contact will be printed in this language. If not, it will be English."
-msgstr ""
-"Si la langue sélectionnée est chargée dans le système, tous les documents de "
-"ce contact seront imprimés dans cette langue. Dans le cas contraire, ils le "
-"seront en anglais."
+msgid "If the selected language is loaded in the system, all documents related to this contact will be printed in this language. If not, it will be English."
+msgstr "Si la langue sélectionnée est chargée dans le système, tous les documents de ce contact seront imprimés dans cette langue. Dans le cas contraire, ils le seront en anglais."
+
+#. module: easy_my_coop
+#: model:ir.model.fields,help:easy_my_coop.field_operation_request_subscription_request
+msgid "In case on a transfer of share. If the share receiver isn't a effective member then a subscription form should be filled."
+msgstr "Dans le cas d'un transfert de part. Si la personne qui reçoit les parts n'est pas un membre effectif, le formulaire de demande doit être rempli."
 
 #. module: easy_my_coop
 #: selection:subscription.request,type:0
@@ -1171,9 +1565,20 @@ msgstr "Augmentation de part"
 
 #. module: easy_my_coop
 #: model:ir.model,name:easy_my_coop.model_account_invoice
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_invoice
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "Invoice"
 msgstr "Facture"
+
+#. module: easy_my_coop
+#: model:ir.model,name:easy_my_coop.model_account_invoice_report
+msgid "Invoices Statistics"
+msgstr "Statistiques des factures"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_is_operation
+msgid "Is Operation request"
+msgstr "Est une demande d'opération"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_is_company
@@ -1183,17 +1588,27 @@ msgstr "Est une société"
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 msgid "Is a company?"
-msgstr "Est une société?"
+msgstr "Est une société ?"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_is_company
+msgid "Is company"
+msgstr "Est une entreprise"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_product_template_is_share
 msgid "Is share?"
-msgstr "Est une part?"
+msgstr "Est une part ?"
 
 #. module: easy_my_coop
 #: model:ir.model,name:easy_my_coop.model_account_journal
 msgid "Journal"
 msgstr "Journal"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,help:easy_my_coop.field_subscription_request_capital_release_request_date
+msgid "Keep empty to use the current date"
+msgstr "Laissez vide pour utiliser la date courante"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
@@ -1214,6 +1629,9 @@ msgid "Language..."
 msgstr "Langue..."
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request___last_update
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription___last_update
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info___last_update
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line___last_update
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register___last_update
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request___last_update
@@ -1227,6 +1645,9 @@ msgid "Last Name"
 msgstr "Nom"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_write_uid
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_write_uid
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_write_uid
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_write_uid
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_write_uid
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_write_uid
@@ -1234,6 +1655,9 @@ msgid "Last Updated by"
 msgstr "Mis à jour par"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_write_date
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_write_date
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_write_date
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_write_date
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_write_date
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_write_date
@@ -1244,6 +1668,17 @@ msgstr "Mis à jour le"
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_lastname
 msgid "Lastname"
 msgstr "Nom"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_representative
+msgid "Legal Representative"
+msgstr "Représentant légal"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
+#: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
+msgid "Logged"
+msgstr "Connecté"
 
 #. module: easy_my_coop
 #: model:ir.actions.act_window,name:easy_my_coop.action_easy_my_coop_email_templates
@@ -1257,14 +1692,27 @@ msgid "Main Address"
 msgstr "Siège social"
 
 #. module: easy_my_coop
+#: code:addons/easy_my_coop/models/coop.py:118
+#: selection:res.partner,gender:0
+#: selection:subscription.request,gender:0
+#, python-format
+msgid "Male"
+msgstr "Masculin"
+
+#. module: easy_my_coop
 #: model:res.groups,name:easy_my_coop.group_energiris_manager
 msgid "Manager"
 msgstr "Responsable"
 
 #. module: easy_my_coop
+#: selection:subscription.request,source:0
+msgid "Manual"
+msgstr "Manuel"
+
+#. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_res_company_subscription_maximum_amount
 msgid "Maximum authorized subscription amount"
-msgstr "Montant maximum de soucription"
+msgstr "Montant maximum de souscription"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_product_template_minimum_quantity
@@ -1278,7 +1726,6 @@ msgid "Name"
 msgstr "Nom"
 
 #. module: easy_my_coop
-#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_company_register_number
 #: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_national_register_number
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_no_registre
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
@@ -1303,41 +1750,46 @@ msgid "Number of Share"
 msgstr "Nombre de parts"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_quantity
 #: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_number_of_share
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_quantity
 msgid "Number of share"
 msgstr "Nombre de parts"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_old_member
+msgid "Old cooperator"
+msgstr "Ancien cooperateur"
+
+#. module: easy_my_coop
+#: model:ir.actions.act_window,help:easy_my_coop.action_company_representative_form
 #: model:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_candidate_form
 #: model:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_form
-msgid ""
-"OpenERP helps you easily track all activities related to\n"
-"                a cooperator: discussions, history of business "
-"opportunities,\n"
+msgid "OpenERP helps you easily track all activities related to\n"
+"                a cooperator: discussions, history of business opportunities,\n"
 "                documents, etc."
-msgstr ""
-"OpenERP helps you easily track all activities related to\n"
-"                a cooperator: discussions, history of business "
-"opportunities,\n"
+msgstr "OpenERP helps you easily track all activities related to\n"
+"                a cooperator: discussions, history of business opportunities,\n"
 "                documents, etc."
 
 #. module: easy_my_coop
 #: model:ir.actions.act_window,help:easy_my_coop.action_invoice_tree_coop
-msgid ""
-"OpenERP's electronic invoicing allows to ease and fasten the\n"
-"                collection of cooperator payments. The cooperator customer "
-"receives the\n"
+msgid "OpenERP's electronic invoicing allows to ease and fasten the\n"
+"                collection of cooperator payments. The cooperator customer receives the\n"
 "                invoice by email and he can pay online and/or import it\n"
 "                in his own system."
-msgstr ""
-"OpenERP's electronic invoicing allows to ease and fasten the\n"
-"                collection of cooperator payments. The cooperator customer "
-"receives the\n"
+msgstr "OpenERP's electronic invoicing allows to ease and fasten the\n"
+"                collection of cooperator payments. The cooperator customer receives the\n"
 "                invoice by email and he can pay online and/or import it\n"
 "                in his own system."
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_operation_request_id
+msgid "Operation Request"
+msgstr "Demande de transaction"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_operation_type
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_type
 msgid "Operation Type"
 msgstr "Type d'opération"
@@ -1348,17 +1800,28 @@ msgid "Operation number"
 msgstr "Numéro d'opération"
 
 #. module: easy_my_coop
+#: model:ir.actions.act_window,name:easy_my_coop.operation_request_action
+#: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_operation_request
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
+msgid "Operation request"
+msgstr "Demande de transaction"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_tree
+msgid "Operation requests"
+msgstr "Demandes de transaction"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_subscription_G001
 msgid "Operation type"
 msgstr "Type d'opération"
 
 #. module: easy_my_coop
-#: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
-msgid "Operational Address"
-msgstr "Siège d'activité"
-
-#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/coop.py:120
+#: selection:res.partner,gender:0
 #: selection:subscription.request,company_type:0
+#: selection:subscription.request,gender:0
+#, python-format
 msgid "Other"
 msgstr "Autre"
 
@@ -1393,7 +1856,7 @@ msgstr "Type de part"
 #: model:mail.template,subject:easy_my_coop.email_template_certificat
 #: model:mail.template,subject:easy_my_coop.email_template_certificat_increase
 msgid "Payment Received Confirmation"
-msgstr "Confirmation de la réception du paiement"
+msgstr "Confirmation de récéption du paiement"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_phone
@@ -1403,19 +1866,15 @@ msgid "Phone"
 msgstr "Téléphone"
 
 #. module: easy_my_coop
-#: code:addons/easy_my_coop/models/coop.py:143
+#: code:addons/easy_my_coop/models/coop.py:186
 #, python-format
-msgid ""
-"Please define income account for this product: \"%s\" (id:%d) - or for its "
-"category: \"%s\"."
-msgstr ""
-"Please define income account for this product: \"%s\" (id:%d) - or for its "
-"category: \"%s\"."
+msgid "Please define income account for this product: \"%s\" (id:%d) - or for its category: \"%s\"."
+msgstr "Please define income account for this product: \"%s\" (id:%d) - or for its category: \"%s\"."
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_certificat_G001_document
-msgid "Pour le Conseil d'administration de BEES coop SCRLFs."
-msgstr "Pour le Conseil d'administration de BEES coop SCRLFs."
+msgid "Pour le Conseil d'administration de"
+msgstr "Pour le Conseil d'administration de"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
@@ -1442,20 +1901,56 @@ msgid "REQUEST TO RELEASE CAPITAL"
 msgstr "DEMANDE DE LIBERATION DE CAPITAL"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_receiver_not_member
+msgid "Receiver is not a member"
+msgstr "Le receveur n'est pas un membre"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "Refund"
 msgstr "Avoir"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
+msgid "Refuse"
+msgstr "Refuser"
+
+#. module: easy_my_coop
+#: selection:operation.request,state:0
+msgid "Refused"
+msgstr "Refusé"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_register_number
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_update_info_register_number
+msgid "Register Number"
+msgstr "Numéro de registre"
+
+#. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_register_number_operation
 msgid "Register Number Operation"
-msgstr "Register Number Operation"
+msgstr "Numéro d'opération de registre"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_account_invoice_report_release_capital_request
+msgid "Release capital request"
+msgstr "Demande de libération de capital"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_account_invoice_release_capital_request
 msgid "Release of capital request"
 msgstr "Demande de libération de capital"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_representative_name
+msgid "Representative name"
+msgstr "Nom du représentant"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_representative_number
+msgid "Representative national register number"
+msgstr "Numéro national du représentant"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.company_subscription_request_tree
@@ -1464,11 +1959,17 @@ msgid "Request Date"
 msgstr "Date de la demande"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_request_date
+msgid "Request date"
+msgstr "Date de la demande"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.view_subscription_request_filter
 msgid "Request type"
 msgstr "Type de demande"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_user_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_user_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_user_id
 msgid "Responsible"
@@ -1500,6 +2001,7 @@ msgid "Search Subscription Request"
 msgstr "Rechercher les demandes de souscription"
 
 #. module: easy_my_coop
+#: selection:operation.request,operation_type:0
 #: selection:subscription.register,type:0
 msgid "Sell Back"
 msgstr "Revente"
@@ -1516,6 +2018,17 @@ msgid "Share Lines"
 msgstr "Lignes de part"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_share_qty
+msgid "Share Quantity"
+msgstr "Share Quantity"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_subscription_request
+msgid "Share Receiver Info"
+msgstr "Info du receveur des parts"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_share_product
 #: model:ir.ui.view,arch_db:easy_my_coop.company_subscription_request_tree
 #: model:ir.ui.view,arch_db:easy_my_coop.subscription_request_tree
 msgid "Share Type"
@@ -1527,6 +2040,8 @@ msgid "Share number"
 msgstr "Nombre de parts"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_share_unit_price
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_share_unit_price
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_share_unit_price
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_share_unit_price
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_share_unit_price
@@ -1534,7 +2049,18 @@ msgid "Share price"
 msgstr "Prix de la part"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.view_partner_form_easy_my_coop
+msgid "Share subscriptions"
+msgstr "Souscription de part"
+
+#. module: easy_my_coop
+#: model:mail.template,subject:easy_my_coop.email_template_share_transfer
+msgid "Share transfert"
+msgstr "Transfert de part"
+
+#. module: easy_my_coop
 #: model:ir.actions.act_window,name:easy_my_coop.share_product_action
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_share_product_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_share_product_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_share_product_id
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_share_product_id
@@ -1544,11 +2070,17 @@ msgid "Share type"
 msgstr "Type de part"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_share_short_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_share_line_share_short_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_share_short_name
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_share_short_name
 msgid "Share type name"
 msgstr "Nom du type de part"
+
+#. module: easy_my_coop
+#: model:mail.template,subject:easy_my_coop.email_template_share_update
+msgid "Share update"
+msgstr "Mise à jour des parts"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.view_partner_form_easy_my_coop
@@ -1566,13 +2098,26 @@ msgid "Skip control"
 msgstr "Ne pas contrôler"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_source
+msgid "Source"
+msgstr "Source"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_state
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_state
 msgid "State"
 msgstr "État"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
+msgid "Submit"
+msgstr "Soumettre"
+
+#. module: easy_my_coop
 #: model:ir.ui.menu,name:easy_my_coop.menu_easy_my_coop_main_subscription
+#: selection:operation.request,operation_type:0
 #: selection:subscription.register,type:0
+#: selection:subscription.request,type:0
 msgid "Subscription"
 msgstr "Souscription"
 
@@ -1597,7 +2142,7 @@ msgstr "Registre de souscription"
 #. module: easy_my_coop
 #: model:ir.actions.report.xml,name:easy_my_coop.action_cooperator_subscription_report
 msgid "Subscription Register Report"
-msgstr "Rapport du registre de souscription"
+msgstr "Rapport de registre de souscription"
 
 #. module: easy_my_coop
 #: model:ir.model,name:easy_my_coop.model_subscription_request
@@ -1605,11 +2150,14 @@ msgid "Subscription Request"
 msgstr "Demande de souscription"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.operation_request_form
 #: model:ir.ui.view,arch_db:easy_my_coop.subscription_request_form
 msgid "Subscription Requests"
 msgstr "Demandes de souscription"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_subscription_amount
+#: model:ir.model.fields,field_description:easy_my_coop.field_partner_create_subscription_subscription_amount
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_subscription_amount
 msgid "Subscription amount"
 msgstr "Montant de la souscription"
@@ -1625,10 +2173,22 @@ msgid "Subscription date request"
 msgstr "Date de la demande de souscription"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_account_invoice_subscription_request
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_subscription_request_ids
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_capital_release_request
+msgid "Subscription request"
+msgstr "Demande de souscription"
+
+#. module: easy_my_coop
 #: model:mail.template,subject:easy_my_coop.email_template_confirmation
 #: model:mail.template,subject:easy_my_coop.email_template_confirmation_company
 msgid "Subscription request confirmation"
-msgstr "Confirmation de la souscription"
+msgstr "Confirmation de la demande de souscription"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.view_create_subscription
+msgid "Subscription request will be created with data from the partner."
+msgstr "La demande de souscription va être créée avec les données du partenaire."
 
 #. module: easy_my_coop
 #: model:res.groups,name:easy_my_coop.group_energiris_super_manager
@@ -1659,16 +2219,81 @@ msgstr "Taxes"
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_thanks
 msgid "Thanks!"
-msgstr "Merci!"
+msgstr "Merci !"
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/coop.py:298
+#, python-format
+msgid "The checkbox already cooperator is checked please select a cooperator."
+msgstr "La case Déjà coopérateur est cochée. Sélectionnez un coopérateur."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/operation_request.py:129
+#, python-format
+msgid "The cooperator can't hand over more shares that he/she owns."
+msgstr "Le coopérateur ne peut pas transférer ou vendre plus de parts qu'il n'en a."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/operation_request.py:121
+#, python-format
+msgid "The cooperator doesn't own this share type. Please choose the appropriate share type."
+msgstr "Le coopérateur ne possède pas ce type de part. Choisissez un autre type de part."
 
 #. module: easy_my_coop
 #: model:ir.actions.act_window,help:easy_my_coop.action_invoice_tree_coop
-msgid ""
-"The discussions with the cooperator are automatically displayed at\n"
+msgid "The discussions with the cooperator are automatically displayed at\n"
 "                the bottom of each invoice."
-msgstr ""
-"The discussions with the cooperator are automatically displayed at\n"
+msgstr "The discussions with the cooperator are automatically displayed at\n"
 "                the bottom of each invoice."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/wizard/create_subscription_from_partner.py:115
+#: code:addons/easy_my_coop/wizard/update_partner_info.py:30
+#, python-format
+msgid "The national register number is not valid."
+msgstr "Le numéro de registre national n'est pas valide."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/coop.py:325
+#: code:addons/easy_my_coop/wizard/create_subscription_from_partner.py:164
+#, python-format
+msgid "There is two different persons with the same national register number. Please proceed to a merge before to continue"
+msgstr "Il y a deux personnes différentes avec le même numéro de registre national."
+
+#. module: easy_my_coop
+#: model:ir.model.fields,help:easy_my_coop.field_res_company_property_cooperator_account
+msgid "This account will be the default one as the receivable account for the cooperators"
+msgstr "Ce compte sera le compte par défaut comme compte recevable pour les coopérateurs."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/coop.py:327
+#, python-format
+msgid "This contact person is already defined for another company. Please select another contact"
+msgstr "Cette personne de contact est déjà définie pour une autre personne morale. Sélectionnez un autre contact."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/operation_request.py:88
+#, python-format
+msgid "This operation can't be executed if the cooperator is not an effective member"
+msgstr "Cette opération ne peut pas être exécutée si le coopérateur n'est pas un membre effectif."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/operation_request.py:172
+#, python-format
+msgid "This operation is not yet implemented."
+msgstr "L'opération n'est pas encore implémentée."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/operation_request.py:123
+#, python-format
+msgid "This operation must be approved before to be executed"
+msgstr "Cette opération doit être approuvée avant d'être exécutée."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/models/operation_request.py:156
+#, python-format
+msgid "This share type could not be transfered to "
+msgstr "Ce type de part ne peut pas être transféré à"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_certificat_G001_document
@@ -1698,7 +2323,7 @@ msgstr "Total de parts"
 #: model:ir.ui.view,arch_db:easy_my_coop.company_subscription_request_tree
 #: model:ir.ui.view,arch_db:easy_my_coop.subscription_request_tree
 msgid "Total ordered parts"
-msgstr "Total de parts commandés"
+msgstr "Total de parts commandées"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.subscription_register_tree
@@ -1713,12 +2338,19 @@ msgstr "Montant total souscrit"
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_res_partner_total_value
 msgid "Total value of shares"
-msgstr "Valeur total des parts"
+msgstr "Valeur totale des parts"
 
 #. module: easy_my_coop
+#: selection:operation.request,operation_type:0
 #: selection:subscription.register,type:0
 msgid "Transfer"
 msgstr "Transfert"
+
+#. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_partner_id_to
+#: model:ir.model.fields,field_description:easy_my_coop.field_subscription_register_partner_id_to
+msgid "Transfered to"
+msgstr "Transféré à"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_type
@@ -1732,9 +2364,40 @@ msgid "Unit Price"
 msgstr "Prix unitaire"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_res_company_unmix_share_type
+msgid "Unmix share type"
+msgstr "Ne pas mélanger le type de part"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.view_subscription_request_filter
 msgid "Unvalid"
 msgstr "Non valide"
+
+#. module: easy_my_coop
+#: model:ir.actions.act_window,name:easy_my_coop.action_view_update_partner_info
+#: model:ir.ui.view,arch_db:easy_my_coop.view_update_partner_info
+msgid "Update Cooperator Info"
+msgstr "Mise à jour des info coopérateur"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.view_update_partner_info
+msgid "Update Cooperator Info."
+msgstr "Mise à jour des infos coopérateur."
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.view_update_partner_info
+msgid "Update Info"
+msgstr "Mise à jour d'infos"
+
+#. module: easy_my_coop
+#: model:ir.model,name:easy_my_coop.model_partner_update_info
+msgid "Update Partner Info"
+msgstr "Mise à jour d'infos du partenaire"
+
+#. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.view_partner_form_easy_my_coop
+msgid "Update info"
+msgstr "Mise à jour d'infos"
 
 #. module: easy_my_coop
 #: model:res.groups,name:easy_my_coop.group_energiris_user
@@ -1744,7 +2407,7 @@ msgstr "Utilisateur"
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_validated
 msgid "Valid Line?"
-msgstr "Ligne valide?"
+msgstr "Ligne valide ?"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.subscription_request_form
@@ -1762,9 +2425,19 @@ msgid "Vendor Refund"
 msgstr "Avoir fournisseur"
 
 #. module: easy_my_coop
+#: selection:operation.request,state:0
+msgid "Waiting"
+msgstr "En attente"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_thanks
 msgid "We will get back to you shortly."
 msgstr "Nous reviendrons rapidement vers vous."
+
+#. module: easy_my_coop
+#: selection:subscription.request,source:0
+msgid "Website"
+msgstr "Website"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_account_invoice_website_message_ids
@@ -1777,9 +2450,14 @@ msgid "Website communication history"
 msgstr "Historique de communication du site web"
 
 #. module: easy_my_coop
+#: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
+msgid "You have already an account?"
+msgstr "Vous avez déjà un compte ? Cliquez ici pour vous connecter."
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_thanks
-msgid "Your message has been sent successfully."
-msgstr "Votre message a été envoyé avec succès."
+msgid "Your subscription has been successfully registered."
+msgstr "Votre souscription a été enregistrée."
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request_zip_code
@@ -1790,11 +2468,6 @@ msgstr "Code postal"
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 msgid "administration@beescoop.be"
 msgstr "administration@beescoop.be"
-
-#. module: easy_my_coop
-#: model:ir.model,name:easy_my_coop.model_cooperator_number_wizard
-msgid "cooperator.number.wizard"
-msgstr "cooperator.number.wizard"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
@@ -1816,29 +2489,28 @@ msgstr "brouillon"
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
 msgid "e.g. (+32).81.81.37.00"
-msgstr "e.g. (+32).81.81.37.00"
+msgstr "ex. (+32).81.81.37.00"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,help:easy_my_coop.field_subscription_request_skip_control_ng
-msgid ""
-"if this field is checked then no control will be done on the national "
-"register number and on the iban bank account. To be done in case of the id "
-"card is from abroad or in case of a passport"
-msgstr ""
-"if this field is checked then no control will be done on the national "
-"register number and on the iban bank account. To be done in case of the id "
-"card is from abroad or in case of a passport"
+msgid "if this field is checked then no control will be done on the national register number and on the iban bank account. To be done in case of the id card is from abroad or in case of a passport"
+msgstr "Si cette case est cochée, aucun contrôle ne sera fait sur le numéro de registre national ou sur le compte IBAN. A faire dans le cas où une carte d'identité étrangère ou un passeport est référencé."
+
+#. module: easy_my_coop
+#: model:ir.model,name:easy_my_coop.model_operation_request
+msgid "operation.request"
+msgstr "Demande de transaction"
+
+#. module: easy_my_coop
+#: selection:subscription.request,state:0
+msgid "paid"
+msgstr "payé"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
 #: model:ir.ui.view,arch_db:easy_my_coop.becomecooperator
 msgid "rue Van Hove, 19"
 msgstr "Van Hovestraat, 19"
-
-#. module: easy_my_coop
-#: model:ir.ui.view,arch_db:easy_my_coop.becomecompanycooperator
-msgid "rue du brochet, 48"
-msgstr "du brochetstraat, 48"
 
 #. module: easy_my_coop
 #: model:ir.model,name:easy_my_coop.model_share_line


### PR DESCRIPTION
This fix weird 't' appearing in the translation of emails. There was a
mix of space and tab indentation in xml files. Tabulation indentation
generate \t code in fr_BE.po.

So this commit removes the tabulation indetation for xml file and fix
the translation in i18n/fr_BE.po.