### PR TITLE
require data policy approval on part subscription

### DIFF
--- a/easy_my_coop/__openerp__.py
+++ b/easy_my_coop/__openerp__.py
@@ -30,6 +30,7 @@
                 "partner_contact_birthdate",
                 "website",
                 "website_recaptcha_reloaded",
+                "website_legal_page",
                 "theme_light",
                 "base_iban",
                 "email_template_config",

--- a/easy_my_coop/controllers/main.py
+++ b/easy_my_coop/controllers/main.py
@@ -182,11 +182,14 @@ class WebsiteSubscription(http.Controller):
         redirect = "easy_my_coop.becomecooperator"
         if is_company:
            redirect = "easy_my_coop.becomecompanycooperator"
-               
+
+        if kwargs.get('data_policy_approved', 'off') == 'on':
+            values['data_policy_approved'] = True
+
         if not kwargs.has_key('g-recaptcha-response') or not request.website.is_captcha_valid(kwargs['g-recaptcha-response']):
            values = self.fill_values(values,is_company)
            values["error_msg"] = "the captcha has not been validated, please fill in the captcha"
-           
+
            return request.website.render(kwargs.get("view_from", redirect), values)
         
         if not logged and kwargs.has_key('email'):

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -110,7 +110,8 @@ class ResPartner(models.Model):
     effective_date = fields.Date(sting="Effective Date", compute='_compute_effective_date', store=True)
     representative = fields.Boolean(string="Legal Representative")
     subscription_request_ids = fields.One2many('subscription.request', 'partner_id', string="Subscription request")
-    
+    data_policy_approved = fields.Boolean(string="Approved Data Policy")
+
     @api.multi
     @api.depends('subscription_request_ids.state')
     def _compute_coop_candidate(self):
@@ -125,7 +126,7 @@ class ResPartner(models.Model):
                     is_candidate = False
              
             partner.coop_candidate = is_candidate
-            
+
     def has_representative(self):
         if self.child_ids.filtered('representative'):
             return True

--- a/easy_my_coop/view/subscription_template.xml
+++ b/easy_my_coop/view/subscription_template.xml
@@ -70,13 +70,13 @@
 							</label>
 						</div>
 						
-			           <div t-attf-class="form-group">
+             <div t-attf-class="form-group">
 							<label>
 								<input type="checkbox" t-att-value="already_cooperator" name="already_cooperator" />
 								Already cooperator?
 							</label>
 						</div>
-			           
+
 			           <div name="email_from_container" t-attf-class="form-group #{error and 'email_from' in error and 'has-error' or ''}">
 			                <label class="col-md-3 col-sm-4 control-label" for="email">Email</label>
 			                <div class="col-md-7 col-sm-8 bottom-line" style="padding-bottom:20px">
@@ -527,20 +527,24 @@
                 </div>
             </div>
 
-						<table style="margin-left:195px">
-							<tr>
-								<td width="80%">
-									<div class="g-recaptcha" t-att-data-sitekey="website.recaptcha_site_key" data-theme="green"/><br/>			
-								</td>
-								<td>
-			 						<div class="form-group">
-						                <div class="col-md-offset-3 col-sm-offset-4 col-sm-8 col-md-7">
-						                    <button class="btn btn-primary btn-lg">Send</button>
-						                </div>
-						            </div>
-								</td>								
-							</tr> 							
-						</table>			            
+            <div t-attf-class="form-group" >
+                <div class="col-md-7 col-sm-8">
+                  <table style="margin-left:195px">
+                    <tr>
+                      <td width="80%">
+                        <div class="g-recaptcha" t-att-data-sitekey="website.recaptcha_site_key" data-theme="green"/><br/>
+                      </td>
+                      <td>
+                        <div class="form-group">
+                                  <div class="col-md-offset-3 col-sm-offset-4 col-sm-8 col-md-7">
+                                      <button class="btn btn-primary btn-lg">Send</button>
+                                  </div>
+                              </div>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+            </div>
 						
 			            <br/>			            
 					</form>

--- a/easy_my_coop/view/subscription_template.xml
+++ b/easy_my_coop/view/subscription_template.xml
@@ -137,7 +137,7 @@
 	                              <option t-att-value="langue.code" t-att-selected="langue.code == lang"><t t-esc="langue.name"/></option>
 	                          </t>
 	                      </select>
-						  <br/>	                      
+						  <br/>
 						  <div class="bottom-line" style="margin-left:25%;margin-top:35px;width:59%"></div>	                      
 	                    </div>
 
@@ -151,7 +151,7 @@
  			            <div t-attf-class="form-group #{error and 'zip_code' in error and 'has-error' or ''}">
 			                <label class="col-md-3 col-sm-4 control-label" for="zip_code">City</label>
 			                <div class="col-md-7 col-sm-8">
-								<table>			
+								<table>
 									<tr>
 										<td width="20%">
 											<input type="text" class="form-control mandatory-field" name="zip_code" required="True" t-attf-value="#{zip_code or ''}" placeholder="1030"/>
@@ -232,6 +232,26 @@
 		            	<div class="bottom-line" style="margin-left:178px;margin-top:0px;width:61%"></div>							                
 		                		            			            	                    
  						<br/>
+
+            <div t-attf-class="form-group" >
+                <label class="col-md-3 col-sm-4 control-label" for="data_policy_approved">Privacy Policy</label>
+                <div class="col-md-7 col-sm-8">
+                  <table>
+                    <tr>
+                      <td width='15%'>
+                        <input type="checkbox"
+                               class="form-control"
+                               name="data_policy_approved"
+                               required="True"
+                               t-attf-value="#{data_policy_approved or ''}"/>
+                      </td>
+                      <td width='85%'>
+                        La lucidité est la blessure la plus rapprochée du soleil.
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+            </div>
 
 						<table style="margin-left:195px">
 							<tr>
@@ -404,7 +424,7 @@
 			                </div>
 			            </div>
 			            
-	                    <div t-attf-class="form-group #{error and 'phone' in error and 'has-error' or ''}">
+									<div t-attf-class="form-group #{error and 'phone' in error and 'has-error' or ''}">
 			                <label class="col-md-3 col-sm-4 control-label" for="phone">Phone</label>
 			                <div class="col-md-7 col-sm-8 bottom-line" style="padding-bottom:20px">
 			                    <input type="text" class="form-control" name="phone" required="True" t-attf-value="#{phone or ''}" placeholder="e.g. (+32).81.81.37.00"/>

--- a/easy_my_coop/view/subscription_template.xml
+++ b/easy_my_coop/view/subscription_template.xml
@@ -235,40 +235,38 @@
 
             <div t-attf-class="form-group" >
                 <label class="col-md-3 col-sm-4 control-label" for="data_policy_approved">Privacy Policy</label>
-                <div class="col-md-7 col-sm-8">
-                  <table>
-                    <tr>
-                      <td width='15%'>
+                <div class="col-md-1 col-sm-2">
                         <input type="checkbox"
                                class="form-control"
                                name="data_policy_approved"
                                required="True"
                                t-attf-value="#{data_policy_approved or ''}"/>
+                </div>
+                <div class="col-md-6 col-sm-6">
+                        <t t-call="website_legal_page.acceptance_full"/>
+                </div>
+            </div>
+
+            <div t-attf-class="form-group" >
+                <div class="col-md-7 col-sm-8">
+                  <table style="margin-left:195px">
+                    <tr>
+                      <td width="80%">
+                        <div class="g-recaptcha" t-att-data-sitekey="website.recaptcha_site_key" data-theme="green"/><br/>
                       </td>
-                      <td width='85%'>
-                        La lucidité est la blessure la plus rapprochée du soleil.
+                      <td>
+                        <div class="form-group">
+                                  <div class="col-md-offset-3 col-sm-offset-4 col-sm-8 col-md-7">
+                                      <button class="btn btn-primary btn-lg">Send</button>
+                                  </div>
+                              </div>
                       </td>
                     </tr>
                   </table>
                 </div>
             </div>
 
-						<table style="margin-left:195px">
-							<tr>
-								<td width="80%">
-									<div class="g-recaptcha" t-att-data-sitekey="website.recaptcha_site_key" data-theme="green"/><br/>			
-								</td>
-								<td>
-			 						<div class="form-group">
-						                <div class="col-md-offset-3 col-sm-offset-4 col-sm-8 col-md-7">
-						                    <button class="btn btn-primary btn-lg">Send</button>
-						                </div>
-						            </div>
-								</td>								
-							</tr> 							
-						</table>			            
-						
-			            <br/>			            
+			            <br/>
 					</form>
                 </div>
             </div>
@@ -514,6 +512,20 @@
 		            	<div class="bottom-line" style="margin-left:178px;margin-top:0px;width:61%"></div>							                
 		                		            			            	                    
  						<br/>
+
+            <div t-attf-class="form-group" >
+                <label class="col-md-3 col-sm-4 control-label" for="data_policy_approved">Privacy Policy</label>
+                <div class="col-md-1 col-sm-2">
+                        <input type="checkbox"
+                               class="form-control"
+                               name="data_policy_approved"
+                               required="True"
+                               t-attf-value="#{data_policy_approved or ''}"/>
+                </div>
+                <div class="col-md-6 col-sm-6">
+                        <t t-call="website_legal_page.acceptance_full"/>
+                </div>
+            </div>
 
 						<table style="margin-left:195px">
 							<tr>

--- a/easy_my_coop/view/subscription_template.xml
+++ b/easy_my_coop/view/subscription_template.xml
@@ -70,13 +70,19 @@
 							</label>
 						</div>
 						
-             <div t-attf-class="form-group">
-							<label>
-								<input type="checkbox" t-att-value="already_cooperator" name="already_cooperator" />
-								Already cooperator?
-							</label>
-						</div>
-
+            <div t-attf-class="form-group">
+              <div class="row">
+                <label class="col-md-3 col-sm-4 control-label" for="already_cooperator">Already cooperator?</label>
+                <div class="col-md-2 col-sm-2">
+                        <input type="checkbox"
+                               class="form-control"
+                               name="already_cooperator"
+                               t-att-value="already_cooperator"
+                        />
+                </div>
+              </div>
+            </div>
+			           
 			           <div name="email_from_container" t-attf-class="form-group #{error and 'email_from' in error and 'has-error' or ''}">
 			                <label class="col-md-3 col-sm-4 control-label" for="email">Email</label>
 			                <div class="col-md-7 col-sm-8 bottom-line" style="padding-bottom:20px">


### PR DESCRIPTION
- add field `data_policy_approved` in `res.partner`
- add field `data_policy_approved` in `subscription.request`
- pass `data_policy_approved` in `get_partner_vals` and `get_partner_company_vals`
- added a checkbox and textbox in `subscription_template.xml`
- in the `WebsiteSubscription` controller: check if `data_policy_approved` is checked, pass it as a boolean


J'ai essayé de faire quelque chose de propre dans le formulaire de souscription, mais j'ai misérablement échoué.

~Il était demandé de rendre le texte d'explication à coté de la checkbox configurable. Mais je ne sais pas où ranger ce genre de configration. Pareil pour le lien vers un document explicatif ou une adresse email de contact.~