### PR TITLE
[FIX] easy_my_coop: use firstname and lastname

### DIFF
--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -254,7 +254,7 @@ class subscription_request(models.Model):
         return partner_vals
     
     def get_partner_vals(self):
-        partner_vals = {'name':self.name, 'first_name':self.firstname, 'last_name': self.lastname,
+        partner_vals = {'name':self.name, 'firstname':self.firstname, 'lastname': self.lastname,
                         'gender':self.gender,'cooperator':True, 'street':self.address,'zip':self.zip_code,
                         'city': self.city, 'phone': self.phone, 'email':self.email,
                         'national_register_number':self.no_registre, 'out_inv_comm_type':'bba',
@@ -323,7 +323,7 @@ class subscription_request(models.Model):
                 if contact:
                     contact.type = 'representative'
             if not contact:
-                contact_vals = {'name':self.name, 'first_name':self.firstname, 'last_name': self.lastname,
+                contact_vals = {'name':self.name, 'firstname':self.firstname, 'lastname': self.lastname,
                             'customer':False, 'is_company':False, 'cooperator':True, 
                             'street':self.address,'zip':self.zip_code,'gender':self.gender,
                             'city': self.city, 'phone': self.phone, 'email':self.email,


### PR DESCRIPTION
# Cleaning up first/last names

## Contexte

> Avant ce commit:  
[https://github.com/beescoop/Obeesdoo/commit/51e1c1e346eb6ab53fe62866af76e48cfe5cd70f#diff-4d07185a6ca5e1a4c22f21e06740b293](https://github.com/beescoop/Obeesdoo/commit/51e1c1e346eb6ab53fe62866af76e48cfe5cd70f#diff-4d07185a6ca5e1a4c22f21e06740b293)  
dans la bees nous utilisions les champs first\_name et last\_name. Le module partner_firstname de l'oca définit lui par contre les champs firstname et lastname.  
  
> J'ai donc dans les modules bees changer pour ces deux champs, toujours dans l'idée d'être compatible. Sauf que j'ai remarqué (à l'époque) que **easy\_my\_coop malgré qu'il dépend de partner\_firstname utilisait les champs first\_name et last_name...** du coup dans le module que j'ai écris j'ai créer les deux champs l'un étant related de l'autre histoire qu'on puisse indifféremment, lire et écrire l'un ou l'autre.   
  
> Idéalement tout le code, qui utilise le module partner_firstname (OCA ou le mien) devrait uiliser les champs firstname et lastname. c'est déjà le cas pour les module de la beescoop.

\- Mouloud

Effectivement, dans `houssine78/partner_firstname`, copie du module de l'OCA:

```python
class ResPartner(models.Model):  
    """Adds last name and first name; name becomes a stored function field."""  
   _inherit = 'res.partner'  
  
   firstname = fields.Char("First name")  
    lastname = fields.Char("Last name")
```
Et dans `obeesdoo/partner_fistname`:

```python
class Partner(models.Model):
    _inherit = 'res.partner'
    firstname = fields.Char('First Name')  
    lastname = fields.Char('Last Name', required=True, default="/")  
    ...
    #Compatibility with old name use in beedoo  
    last_name = fields.Char(related='lastname')  
    first_name = fields.Char(related='firstname')

```

## Todo

- Remplacer dans le code easymycoop les champs `first_name` et `last_name` par `firstname` et `lastname`.